### PR TITLE
Download page cleanups

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -77,11 +77,6 @@
                 <th>i386</th>
             </tr>
             <tr>
-                <td>1.2</td>
-                <td><a href="1.2-release-amd64.metalink">download</a></td>
-                <td><a href="1.2-release-i386.metalink">download</a></td>
-            </tr>
-            <tr>
                 <td>1.1</td>
                 <td><a href="1.1-release-amd64.metalink">download</a></td>
                 <td><a href="1.1-release-i386.metalink">download</a></td>

--- a/download/index.html
+++ b/download/index.html
@@ -205,7 +205,7 @@
                     is no password. DHCP is enabled. X.org 6.9 and perl are installed.
                 </td>
                 <td class="down">
-                    <a href="/ftp/MidnightBSD/virtualmachines/MidnightBSD.zip">main site</a>
+                    <a href="/ftp/MidnightBSD/virtualmachines/0.1/MidnightBSD.zip">main site</a>
                 </td>
             </tr>
             <tr>
@@ -217,7 +217,7 @@
                     is no password. DHCP is enabled. X.org 6.9 and perl are installed.
                 </td>
                 <td class="down">
-                    <a href="/ftp/MidnightBSD/virtualmachines/mnbsd-parallels.zip">main site</a>
+                    <a href="/ftp/MidnightBSD/virtualmachines/0.1/mnbsd-parallels.zip">main site</a>
                 </td>
             </tr>
 			</tbody>


### PR DESCRIPTION
This fixes links for two ancient VM images and removes metalink references for 1.2 for which no metalinks exist. If there are plans to continue using metalink, MidnightBSD should probably adopt v4 for 1.2 and newer releases as that's the proper standard. I'm not sure, though, if it makes a lot of sense today.

Next question is: What to do about emule? The link doesn't work anymore and while the emule network still exists, it is far from as popular as it once was. When I saw the link, for a moment I felt like I was in the wrong decade. ;) If 2.0 is to be made available via emule, too, the link should be fixed. Otherwise I'd like to remove it.