### PR TITLE
Typo fixes and little improvements to documentation

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -22,7 +22,7 @@
 							width="150" height="150" alt="Midnight the cat" /></a><br>The "Midnight" in MidnightBSD</p>
 					</div>
 
-					<p>MidnightBSD is a FreeBSD derived Operating System. A critical goal of 
+					<p>MidnightBSD is a FreeBSD-derived Operating System. A critical goal of
 					the project is to create an easy to use desktop environment with graphical ports 
 					management, and system configuration using Xfce. The vast majority of the
 					operating system will maintain a BSD license. Certain software packages use 
@@ -40,7 +40,7 @@
 					allocation of resources, security settings, and available application support
 					should be tailored to desktop users. Many of the BSD projects are tailored to 
 					servers or older hardware. Others are distributions of FreeBSD with a nice 
-					graphical user interface, but still suffer from server centric design under 
+					graphical user interface, but still suffer from server-centric design under
 					the hood. We did not fork FreeBSD as a result of a falling out, but rather 
 					as an excellent starting point. It should be viewed as a compliment to the
 					FreeBSD developers who have worked very hard on FreeBSD 5.x and 6.x.</p>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -48,16 +48,16 @@
 				<p>While MidnightBSD plans to target moderate and novice users, currently installation 
 				is too difficult for beginners to *NIX like operating systems. Experience with BSD, 
 				Linux, or another *NIX like system is very helpful. FreeBSD users familiar with 
-				sysinstall should have no problem with this procedure. You may also consult the
+				bsdinstall should have no problem with this procedure. You may also consult the
 				<a href="http://www.freebsd.org/handbook">FreeBSD Handbook</a> for additional information 
 				not found on this page.</p>
 				
 				<h4 id="s1c">Preparing For Installation</h4>
 				<p>You may download MidnightBSD from our FTP server or any mirrors, provided that you have a
-				broadband internet connection. You will need disk 1 of a release or snapshot in order to install MidnightBSD.</p>
+				broadband internet connection. You will need disk 1 of a release in order to install MidnightBSD.</p>
 				<p>You will need free space on your hard drive. While the system runs very well on a few gigabytes of disk space, we recommend at least 
 				15GB of space for use with mports on a desktop. An Intel Pentium class computer or equivalent is required. We have removed 486 support 
-				from the default install, although it can be compiled in. At least 48MB of RAM is required for installation.</p>
+				from the default install, although it can be compiled in. At least 96MB of RAM is required for installation.</p>
 				<p>Depending on your needs, various graphics cards are supported at different levels. Many network cards are
 				supported as well as a few wireless network cards. We will document them at a later time.
 				Many onboard audio controllers are supported as well as other cards like the 
@@ -92,12 +92,10 @@
 				this screen, please report it. There maybe a bug or an incompatibility with your 
 				system we can work to fix.
 				</p>
-				<p>From this point, you may follow the steps in sysinstall to complete installation. 
-				On snapshots, X11 (XORG) and packages are not present. Do not attempt to install 
-				these items or you will receive errors. We hope to resolve this by 0.2 release.
+				<p>From this point, you may follow the steps in bsdinstall to complete installation.
 				</p>
 
-				<p>You may follow along with the BSD Magazine article on 
+				<p>If you are interested in legacy releases, you  may follow along with the BSD Magazine article on
 				<a href="http://bsdmag.org/download/bsd-2010-archives/">installing MidnightBSD.</a> in the August 2010 issue.  This procedure covers 0.1-RELEASE - 0.3-RELEASE. 0.4 installs are a bit different. There are also some <a href="http://www.youtube.com/watch?v=caZ2KpLehW4">YouTube videos</a> available for older releases.</p>
 
 

--- a/security/index.html
+++ b/security/index.html
@@ -30,7 +30,7 @@
 
         <h3>mport Software Packages</h3>
 
-        <p>For third party security adviories related to packages, try the new <a href="http://sec.midnightbsd.org/#!/">Security
+        <p>For third party security advisories related to packages, try the new <a href="http://sec.midnightbsd.org/#!/">Security
             Advisory</a> website. To detect
             vulnerable software packages installed on the system, install the security advisory client.
             <i>mport install security-advisory-client</i>. Then simply run advisory.pl to check your system.</p>


### PR DESCRIPTION
As MidnightBSD has been using bsdinstall(8) for quite some time now, I updated the documentation accordingly. Also I assume that there are no longer any snapshots available (please correct me if I'm wrong), so I removed the reference to those. With 2.0, the kernel won't even boot with 64 MB of RAM or less, so the wrong info had to be corrected, too.

I didn't want to go too snappy on the documentation, but if there's interest in a more complete revision, I could probably do some work. Especially the developer page could use a bit of love (and introduction to the git workflow).