### PR TITLE
🛡️ Sentinel: [security improvement] Use HTTPS for MidnightBSD subdomains

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
 
 		<div id="tweets" class="col-md-4">
 			<p>View available <a href="mports/">mports</a></p>
-			<p><b><a href="http://app.midnightbsd.org/">MidnightBSD App Store</a></b></p>
+			<p><b><a href="https://app.midnightbsd.org/">MidnightBSD App Store</a></b></p>
 
 			<img src="art/midnight20_small.png" alt="MidnightBSD 20th Anniversary" width="275" height="275">
 		</div>

--- a/menu.html
+++ b/menu.html
@@ -18,7 +18,7 @@
                 <ul>
                     <li><a href="/notes/">&nbsp;Release Notes</a></li>
                     <li><a href="/mirmon/" rel=nofollow>&nbsp;Mirror Status</a></li>
-		    <li><a href="http://app.midnightbsd.org/">&nbsp;App Store</li>
+		    <li><a href="https://app.midnightbsd.org/">&nbsp;App Store</li>
                 </ul>
             </li>
         </ul>
@@ -47,7 +47,7 @@
                 <ul>
                     <li><a href="https://github.com/MidnightBSD/src/issues">&nbsp;OS Bugs</a></li>
                     <li><a href="https://github.com/MidnightBSD/mports/issues">&nbsp;mports Bugs</a></li>
-                    <li><a href="http://www.midnightbsd.org/opengrok/" rel=nofollow>&nbsp;openGrok</a></li>
+                    <li><a href="https://www.midnightbsd.org/opengrok/" rel=nofollow>&nbsp;openGrok</a></li>
                     <li><a href="/magus/" rel=nofollow>&nbsp;Magus</a></li>
                     <li><a href="https://www.openhub.net/p/mnbsd">&nbsp;Open HUB</a></li>
                 </ul>
@@ -60,7 +60,7 @@
                     <li><a href="https://github.com/MidnightBSD/mports/issues">&nbsp;mports Bugs</a></li>
                     <li><a href="/documentation/">&nbsp;Documentation</a></li>
 		    <li><a href="https://github.com/MidnightBSD/src/wiki">&nbsp;Wiki</a></li>
-		    <li><a href="http://man.midnightbsd.org/">&nbsp;Manuals</a></li>
+		    <li><a href="https://man.midnightbsd.org/">&nbsp;Manuals</a></li>
                     <li><a href="https://app.midnightbsd.org/">&nbsp;App Store</a></li>
                     <li><a href="/mports/">&nbsp;Mports List</a></li>
                     <li><a href="https://sec.midnightbsd.org/">&nbsp;Security Adv DB</a></li>

--- a/menu.html
+++ b/menu.html
@@ -18,7 +18,7 @@
                 <ul>
                     <li><a href="/notes/">&nbsp;Release Notes</a></li>
                     <li><a href="/mirmon/" rel=nofollow>&nbsp;Mirror Status</a></li>
-		    <li><a href="https://app.midnightbsd.org/">&nbsp;App Store</li>
+                    <li><a href="https://app.midnightbsd.org/">&nbsp;App Store</a></li>
                 </ul>
             </li>
         </ul>


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Insecure `http://` links to MidnightBSD subdomains were present in the site's main navigation (`index.html` and `menu.html`), causing navigation to happen over unencrypted HTTP.
🎯 **Impact**: Navigating over unencrypted HTTP exposes users to potential Man-in-the-Middle (MitM) attacks, enabling attackers to intercept traffic or inject malicious code before the user reaches the subdomain.
🔧 **Fix**: Updated all instances of `http://app.midnightbsd.org/`, `http://www.midnightbsd.org/opengrok/`, and `http://man.midnightbsd.org/` to use `https://`.
✅ **Verification**: Verified via `git diff` and search that the targeted `http` URLs were successfully updated to `https` in `index.html` and `menu.html`. Tests and code review passed.

---
*PR created automatically by Jules for task [13350363953397042659](https://jules.google.com/task/13350363953397042659) started by @laffer1*

## Summary by Sourcery

Bug Fixes:
- Replaced insecure HTTP links to MidnightBSD subdomains in the main navigation and homepage with HTTPS variants to avoid unencrypted navigation.