### PR TITLE
Add link to GitHub repository

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -45,6 +45,7 @@
         <ul>
             <li><a href="/developer/">Developers</a>
                 <ul>
+					<li><a href="https://github.com/MidnightBSD/src">&nbsp;GitHub Repository</a></li>
                     <li><a href="https://github.com/MidnightBSD/src/issues">&nbsp;OS Bugs</a></li>
                     <li><a href="https://github.com/MidnightBSD/mports/issues">&nbsp;mports Bugs</a></li>
                     <li><a href="https://www.midnightbsd.org/opengrok/" rel=nofollow>&nbsp;openGrok</a></li>


### PR DESCRIPTION
Add the link to `https://github.com/MidnightBSD/src` on the Developers tab in `menu.html`.

## Summary by Sourcery

New Features:
- Expose the MidnightBSD src GitHub repository as a dedicated entry under the Developers navigation menu.